### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_miniqr.py
+++ b/adafruit_miniqr.py
@@ -93,7 +93,7 @@ class QRCode:
     def add_data(self, data):
         """Add more data to the QR code, must be bytestring stype"""
         self.data_list.append(data)
-        datalen = sum([len(x) for x in self.data_list])
+        datalen = sum(len(x) for x in self.data_list)
         if not self.type:
             for qr_type in range(1, 6):
                 rs_blocks = _get_rs_blocks(qr_type, self.ECC)


### PR DESCRIPTION
Fixes the following `pylint` errors:

```
************* Module adafruit_miniqr
Error: adafruit_miniqr.py:96:18: R1728: Consider using a generator instead 'sum(len(x) for x in self.data_list)' (consider-using-generator)
```